### PR TITLE
Added library.json for platformio

### DIFF
--- a/library.json
+++ b/library.json
@@ -8,6 +8,6 @@
     "url": "https://github.com/cyosp/AsmTinySerial"
   },
   "version": "1.0.1",
-  "platforms": "*",
+  "platforms": "atmelavr",
   "dependencies": []
 }

--- a/library.json
+++ b/library.json
@@ -1,0 +1,13 @@
+{
+  "name": "AsmTinySerial",
+  "keywords": "ATTINY",
+  "description": "Serial assembler library for AVR ATtiny.",
+  "homepage": "https://github.com/cyosp/AsmTinySerial",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cyosp/AsmTinySerial"
+  },
+  "version": "1.0.1",
+  "platforms": "*",
+  "dependencies": []
+}


### PR DESCRIPTION
…so we can do `pio pkg install -l https://github.com/cyosp/AsmTinySerial.git` and use it as a lib for PlatformIO projects.